### PR TITLE
enabled ZIP64 extension when writing kmz file

### DIFF
--- a/scripts/footprint_fp.py
+++ b/scripts/footprint_fp.py
@@ -522,7 +522,7 @@ def kml_finalise(d,fi,mode,kmlname):
     logger.info(msg)
     plotlist = [p for p in os.listdir('.') if p.endswith(".png")]
     compression = zipfile.ZIP_DEFLATED
-    zf = zipfile.ZipFile(kmzname, mode='w')
+    zf = zipfile.ZipFile(kmzname, mode='w', allowZip64=True)
     zf.write(kmlname, compress_type=compression)
     os.remove(kmlname)
     for f in plotlist:


### PR DESCRIPTION
Hi Cacilia,
I've run the footprint script on the concatenated L3 file (2014-2020) using 500m extent and 100 grid cells. It complain that the kmz file is too large to be compressed. Looks like 64bit is disabled as default in python2. I've changed the code and it runs now. The footprints are all in the .nc file. However, the kmz file doesn't display in google earth. Not sure if it's a size issue (~200MB file.)

> 08:36:02 INFO  Creating KMZ file AU-Cum_kljun_fp.kmz
Exception in Tkinter callback
Traceback (most recent call last):
  File "/home/dan/miniconda3/envs/pfp_env/lib/python2.7/lib-tk/Tkinter.py", line 1541, in __call__
    return self.func(*args)
  File "footprint_GUI.py", line 105, in <lambda>
    doL2Button = tk.Button (self.org_frame, text="Kljun", command=lambda:self.do_footprint(mode="kljun") )
  File "footprint_GUI.py", line 167, in do_footprint
    footprint_fp.footprint_main(cf,mode)
  File "./scripts/footprint_fp.py", line 246, in footprint_main
    kml_finalise(d,fi,mode,kmlname)
  File "./scripts/footprint_fp.py", line 529, in kml_finalise
    zf.write(f, compress_type=compression)
  File "/home/dan/miniconda3/envs/pfp_env/lib/python2.7/zipfile.py", line 1148, in write
    self._writecheck(zinfo)
  File "/home/dan/miniconda3/envs/pfp_env/lib/python2.7/zipfile.py", line 1114, in _writecheck
    " would require ZIP64 extensions")
LargeZipFile: Files count would require ZIP64 extensions

